### PR TITLE
Read-only container

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -25,6 +25,7 @@ RUN echo "==> Installing dependencies..." \
     --prefix=$OPENRESTY_PREFIX \
     --http-client-body-temp-path=$VAR_PREFIX/client_body_temp \
     --http-proxy-temp-path=$VAR_PREFIX/proxy_temp \
+    --http-fastcgi-temp-path=$VAR_PREFIX/fastcgi_temp \
     --http-log-path=$VAR_PREFIX/access.log \
     --error-log-path=$VAR_PREFIX/error.log \
     --pid-path=$VAR_PREFIX/nginx.pid \
@@ -48,12 +49,15 @@ RUN echo "==> Installing dependencies..." \
  && ln -sf $OPENRESTY_PREFIX/bin/resty /usr/local/bin/resty \
  && ln -sf $OPENRESTY_PREFIX/luajit/bin/luajit-* $OPENRESTY_PREFIX/luajit/bin/lua \
  && ln -sf $OPENRESTY_PREFIX/luajit/bin/luajit-* /usr/local/bin/lua \
+ && echo "==> Cleaning..." \
  && apk del \
     make gcc musl-dev pcre-dev openssl-dev zlib-dev ncurses-dev readline-dev curl perl \
  && apk add \
     libpcrecpp libpcre16 libpcre32 openssl libssl1.0 pcre libgcc libstdc++ \
  && rm -rf /var/cache/apk/* \
  && rm -rf /root/ngx_openresty
+
+VOLUME /var/nginx
 
 WORKDIR $NGINX_PREFIX/
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -25,6 +25,7 @@ RUN cd /root \
     --prefix=$OPENRESTY_PREFIX \
     --http-client-body-temp-path=$VAR_PREFIX/client_body_temp \
     --http-proxy-temp-path=$VAR_PREFIX/proxy_temp \
+    --http-fastcgi-temp-path=$VAR_PREFIX/fastcgi_temp \
     --http-log-path=$VAR_PREFIX/access.log \
     --error-log-path=$VAR_PREFIX/error.log \
     --pid-path=$VAR_PREFIX/nginx.pid \
@@ -49,6 +50,8 @@ RUN cd /root \
  && ln -sf $OPENRESTY_PREFIX/luajit/bin/luajit-* $OPENRESTY_PREFIX/luajit/bin/lua \
  && ln -sf $OPENRESTY_PREFIX/luajit/bin/luajit-* /usr/local/bin/lua \
  && rm -rf /root/ngx_openresty*
+
+VOLUME /var/nginx
 
 WORKDIR $NGINX_PREFIX/
 


### PR DESCRIPTION
1. Since fastcgi module is enabled (bbe22b7), a parameter `--http-fastcgi-temp-path` should be passed.
2. Using container in read-only mode (docker/docker#10093) is good for security and maintainability. `docker diff` shows some files are added in `/var/nginx` today. So I suggest to add a volume for this path.

Today :

```
# docker diff shows changes in the root file system

$ docker run -d -P --name openresty ficusio/openresty
163f8649d4c107d9bfac0b8f9d181e0b7fa093f462d04585e1a5c04d93032542
$ docker diff openresty
C /opt
C /opt/openresty
C /opt/openresty/nginx
A /opt/openresty/nginx/fastcgi_temp  # moved with --http-fastcgi-temp-path
C /var
C /var/nginx
A /var/nginx/access.log
A /var/nginx/client_body_temp
A /var/nginx/error.log
A /var/nginx/nginx.pid
A /var/nginx/proxy_temp
```

```
# Tests with read-only root file system (--read-only option)

$ docker run -d -P --name openresty --read-only=true ficusio/openresty
b43ca13b88af9f3c31fccfd03140d62164fb6b17888ee3d8c69d118195e33ed5
$ docker logs openresty
nginx: [alert] could not open error log file: open() "/var/nginx/error.log" failed (30: Read-only file system)
2015/08/05 15:19:18 [emerg] 1#0: mkdir() "/var/nginx/client_body_temp" failed (30: Read-only file system)
```

After this PR : 

```
$ docker run -d -P --name openresty openresty:readonly
85f7122b42956a9e8ac277e1050a3f054054b2c56bdabf9200993bc23450cd38
$ docker diff openresty
     <nothing>

$ docker rm -vf openresty
openresty
$ docker run -d -P --name openresty --read-only=true openresty:readonly
ec7f3ac3f97d336f8096b3836a608e6999c570faaaa5c245f49ac38a7c71b4ed
$ docker logs openresty
2015/08/05 15:43:21 [notice] 1#0: using the "epoll" event method
2015/08/05 15:43:21 [notice] 1#0: openresty/1.7.10.2
2015/08/05 15:43:21 [notice] 1#0: built by gcc 4.9.2 (Alpine 4.9.2) 
2015/08/05 15:43:21 [notice] 1#0: OS: Linux 4.0.7-boot2docker
2015/08/05 15:43:21 [notice] 1#0: getrlimit(RLIMIT_NOFILE): 1048576:1048576
2015/08/05 15:43:21 [notice] 1#0: start worker processes
2015/08/05 15:43:21 [notice] 1#0: start worker process 6
```
