### PR TITLE
Enable the http_stub_status_module

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -38,6 +38,7 @@ RUN echo "==> Installing dependencies..." \
     --without-http_userid_module \
     --without-http_uwsgi_module \
     --without-http_scgi_module \
+    --with-http_stub_status_module \
     -j${NPROC} \
  && echo "==> Building OpenResty..." \
  && make -j${NPROC} \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -37,6 +37,7 @@ RUN cd /root \
     --without-http_userid_module \
     --without-http_uwsgi_module \
     --without-http_scgi_module \
+    --with-http_stub_status_module \
     -j${NPROC} \
  && echo "==> Building OpenResty..." \
  && make -j${NPROC} \


### PR DESCRIPTION
The http_stub_status_module allows us to set up an endpoint that returns server health information. With this, you can use the newrelic nginx module.
